### PR TITLE
Cmake fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,5 @@ Thumbs.db
 *.dll
 *.exe
 
+CMakeLists.txt.*
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.12)
 
 project(lifeSimulator LANGUAGES CXX)
 
@@ -11,52 +11,14 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-# QtCreator supports the following variables for Android, which are identical to qmake Android variables.
-# Check http://doc.qt.io/qt-5/deployment-android.html for more information.
-# They need to be set before the find_package(Qt5 ...) call.
-
-#if(ANDROID)
-#    set(ANDROID_PACKAGE_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/android")
-#    if (ANDROID_ABI STREQUAL "armeabi-v7a")
-#        set(ANDROID_EXTRA_LIBS
-#            ${CMAKE_CURRENT_SOURCE_DIR}/path/to/libcrypto.so
-#            ${CMAKE_CURRENT_SOURCE_DIR}/path/to/libssl.so)
-#    endif()
-#endif()
-
 find_package(Qt5 COMPONENTS Widgets REQUIRED)
 
-if(ANDROID)
-  add_library(lifeSimulator SHARED
-    main.cpp
-    mainwindow.cpp
-    mainwindow.h
-    mainwindow.ui
-  )
-else()
-  add_executable(lifeSimulator
-    main.cpp
-    mainwindow.cpp
-    mainwindow.h
-    mainwindow.ui
-    MainModel/MainModel.h
-    MainModel/MainModel.cpp
-    GUI/AreaWidget.h
-    GUI/AreaWidget.cpp
-    GUI/SettingWidget.h
-    GUI/SettingWidget.cpp
-    GUI/UpPanelWidget.h
-    GUI/UpPanelWidget.cpp
-    GUI/GeneratorsSettingWidget.h
-    GUI/GeneratorsSettingWidget.cpp
-    GUI/StatisticWidget.h
-    GUI/StatisticWidget.cpp
-    Generators/CreaturesGenerator.h
-    Generators/CreaturesGenerator.cpp
-    Generators/FoodGenerator.h
-    Generators/FoodGenerator.cpp
-    .gitignore
-  )
-endif()
+file(GLOB_RECURSE sources CONFIGURE_DEPENDS "*.cpp")
+file(GLOB_RECURSE headers CONFIGURE_DEPENDS "*.h" "*.hpp")
+
+add_executable(lifeSimulator
+  ${sources}
+  ${headers}
+)
 
 target_link_libraries(lifeSimulator PRIVATE Qt5::Widgets)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,7 @@ else()
     Generators/CreaturesGenerator.cpp
     Generators/FoodGenerator.h
     Generators/FoodGenerator.cpp
+    .gitignore
   )
 endif()
 

--- a/Generators/FoodGenerator.cpp
+++ b/Generators/FoodGenerator.cpp
@@ -1,5 +1,5 @@
 #include "FoodGenerator.h"
-
+#include <QDebug>
 
 FoodGenerator::FoodGenerator(CreateFood * createFoodIn,QObject *parent) : QObject(parent)
 {

--- a/MainModel/entity/Food.cpp
+++ b/MainModel/entity/Food.cpp
@@ -1,6 +1,23 @@
 #include "Food.h"
 
-Food::Food()
-{
+#include <QDebug>
 
+Food::Food(int idIn)
+{
+    id=idIn;
+}
+
+void Food::update()
+{
+    age++;
+    qDebug()<<"my age: "<<age<< " my_id: "<<id;
+}
+
+bool Food::isDead() const
+{
+    if(age>180)
+    {
+        return true;
+    }
+    return false;
 }

--- a/MainModel/entity/Food.h
+++ b/MainModel/entity/Food.h
@@ -1,6 +1,6 @@
 #ifndef FOOD_HPP
 #define FOOD_HPP
-#include <QDebug>
+
 #include "public/IOldingFood.h"
 
 class Food: public IOldingFood
@@ -8,23 +8,9 @@ class Food: public IOldingFood
 public:
     int id;
     int age=0;
-    Food(int idIn)
-    {
-        id=idIn;
-    }
-    virtual void update() override
-    {
-        age++;
-        qDebug()<<"my age: "<<age<< " my_id: "<<id;
-    }
-    virtual bool isDead() const override
-    {
-        if(age>180)
-        {
-            return true;
-        }
-        return false;
-    }
+    Food(int idIn);
+    virtual void update() override;
+    virtual bool isDead() const override;
 };
 
 #endif // FOOD_HPP

--- a/MainModel/entity/public/IOldingFood.h
+++ b/MainModel/entity/public/IOldingFood.h
@@ -1,6 +1,5 @@
 #ifndef IOLDINGFOOD_H
 #define IOLDINGFOOD_H
-#pragma once
 
 class IOldingFood
 {


### PR DESCRIPTION
* Update cmake minimum required version to 3.12, because we need to specify src files with GLOB_RECURSE and CONFIGURE_DEPENDS flags 
* Fix some code issues

How to update cmake on Ubuntu:

If you are using a minimal Ubuntu image or a Docker image, you may need to install the following packages:
```bash
sudo apt-get update
sudo apt-get install apt-transport-https ca-certificates gnupg \
                         software-properties-common wget
```
Obtain a copy of our signing key:
```bash
wget -qO - https://apt.kitware.com/keys/kitware-archive-latest.asc |
    sudo apt-key add -
```
Add the repository to your sources list and update.

For Ubuntu Bionic Beaver (18.04):
```bash
sudo apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main'
sudo apt-get update
```

For Ubuntu Xenial Xerus (16.04):
```bash
sudo apt-add-repository 'deb https://apt.kitware.com/ubuntu/ xenial main'
sudo apt-get update
```
Now call
```bash
sudo apt-get install cmake
```